### PR TITLE
feat: added UI for handling namespace maintainers

### DIFF
--- a/flask/user.py
+++ b/flask/user.py
@@ -279,9 +279,11 @@ def add_maintainers_to_package(username):
         return jsonify({"message": "Package not found", "code": 404}), 404
 
     # Check if the current user has authority to add maintainers.
+    # Package maintainer, Namespace maintainer or Namespace admin has the authority to add package maintainers.
     if not checkIsMaintainer(
         user_id=user["_id"], package=curr_package
-    ) and not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace):
+    ) and not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace
+        ) and not checkIfNamespaceMaintainer(user_id=user["_id"], namespace=package_namespace):
         return jsonify({"message": "Unauthorized", "code": 401}), 401
 
     # Get the user to be added using the username received in the request body.
@@ -359,7 +361,9 @@ def remove_maintainers_from_package(username):
         return jsonify({"message": "Package not found", "code": 404}), 404
 
     # Check if the current user has authority to remove maintainers.
-    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace):
+    # Package maintainer, Namespace maintainer or Namespace admin has the authority to remove package maintainers.
+    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=package_namespace
+        ) and not checkIfNamespaceMaintainer(user_id=user["_id"], namespace=package_namespace):
         return (
             jsonify(
                 {"message": "User is not authorized to remove maintainers", "code": 401}

--- a/flask/user.py
+++ b/flask/user.py
@@ -39,10 +39,17 @@ def profile(username):
         if namespaces:
             # Iterate over all the namespaces and add it to the response_namespace.
             for namespace in namespaces:
+                isNamespaceAdmin = False
+
+                # Check if the user is adming of the namespace.
+                if user_doc["_id"] in namespace["admins"]:
+                    isNamespaceAdmin = True
+
                 response_namespaces.append({
                     "id": str(namespace["_id"]),
                     "name": namespace["namespace"],
                     "description": namespace["description"],
+                    "isNamespaceAdmin": isNamespaceAdmin
                 })
 
                 # Iterate over all the packages in the namespace.

--- a/registry/src/pages/addNamespaceMaintainerDialogForm.js
+++ b/registry/src/pages/addNamespaceMaintainerDialogForm.js
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import {
+  addNamespaceMaintainer,
+  resetMessages,
+} from "../store/actions/namespaceMaintainersActions";
+
+const AddNamespaceMaintainerFormDialog = (props) => {
+  const [username, setUsername] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const currUsername = useSelector((state) => state.auth.username);
+  const uuid = useSelector((state) => state.auth.uuid);
+  const successMessage = useSelector(
+    (state) => state.addRemoveNamespaceMaintainer.successMessage
+  );
+  const errorMessage = useSelector(
+    (state) => state.addRemoveNamespaceMaintainer.errorMessage
+  );
+
+  const dispatch = useDispatch();
+
+  const onSubmit = (event) => {
+    dispatch(resetMessages());
+    event.preventDefault();
+
+    // If the form input is not valid. Do not proceed.
+    if (!validateForm()) {
+      return;
+    }
+
+    dispatch(
+      addNamespaceMaintainer(
+        {
+          uuid: uuid,
+          namespace: props.namespace,
+          username_to_be_added: username,
+        },
+        currUsername
+      )
+    );
+  };
+
+  const resetData = () => {
+    setUsername("");
+    setValidationError("");
+    dispatch(resetMessages());
+  };
+
+  const validateForm = () => {
+    if (!username) {
+      setValidationError("Username is required");
+      return false;
+    }
+
+    setValidationError("");
+    return true;
+  };
+
+  return (
+    <form id="add-maintainer-form">
+      <Modal
+        {...props}
+        size="md"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        onExit={resetData}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Add namespace maintainer
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <label>Enter username</label>
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            value={username}
+            id="add-maintainer-input"
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {validationError && (
+            <p id="add-maintainer-error">{validationError}</p>
+          )}
+          {successMessage && (
+            <p id="add-maintainer-success">{successMessage}</p>
+          )}
+          {errorMessage && <p id="add-maintainer-error">{errorMessage}</p>}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="success" onClick={onSubmit}>
+            Add
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </form>
+  );
+};
+
+export default AddNamespaceMaintainerFormDialog;

--- a/registry/src/pages/dashboard.js
+++ b/registry/src/pages/dashboard.js
@@ -105,12 +105,16 @@ const Dashboard = () => {
                   show={addMaintainerDialogState[element.id]}
                   onHide={() => handleAddMaintainerDialog(element.id, false)}
                 />
-                <div
-                  className="border border-danger rounded-pill chip-action"
-                  onClick={() => handleRemoveMaintainerDialog(element.id, true)}
-                >
-                  Remove Maintainers
-                </div>
+                {element.isNamespaceMaintainer ? (
+                  <div
+                    className="border border-danger rounded-pill chip-action"
+                    onClick={() =>
+                      handleRemoveMaintainerDialog(element.id, true)
+                    }
+                  >
+                    Remove Maintainers
+                  </div>
+                ) : null}
                 <RemoveMaintainerFormDialog
                   package={element.name}
                   namespace={element.namespace}

--- a/registry/src/pages/dashboard.js
+++ b/registry/src/pages/dashboard.js
@@ -172,12 +172,17 @@ const Dashboard = () => {
                   show={addMaintainerDialogState[element.id]}
                   onHide={() => handleAddMaintainerDialog(element.id, false)}
                 />
-                <div
-                  className="border border-danger rounded-pill chip-action"
-                  onClick={() => handleRemoveMaintainerDialog(element.id, true)}
-                >
-                  Remove maintainers
-                </div>
+                {element.isNamespaceAdmin ? (
+                  <div
+                    className="border border-danger rounded-pill chip-action"
+                    onClick={() =>
+                      handleRemoveMaintainerDialog(element.id, true)
+                    }
+                  >
+                    Remove maintainers
+                  </div>
+                ) : null}
+
                 <RemoveNamespaceMaintainerFormDialog
                   namespace={element.name}
                   show={removeMaintainerDialogState[element.id]}

--- a/registry/src/pages/dashboard.js
+++ b/registry/src/pages/dashboard.js
@@ -10,6 +10,8 @@ import Container from "react-bootstrap/Container";
 import AddMaintainerFormDialog from "./addMaintainerDialogForm";
 import RemoveMaintainerFormDialog from "./removeMaintainerDialogForm";
 import GenerateNamespaceTokenDialogForm from "./generateNamespaceTokenDialogForm";
+import AddNamespaceMaintainerFormDialog from "./addNamespaceMaintainerDialogForm";
+import RemoveNamespaceMaintainerFormDialog from "./removeNamespaceMaintainerDialogForm";
 
 const Dashboard = () => {
   const [addMaintainerDialogState, setAddMaintainerDialogState] = useState({});
@@ -92,7 +94,6 @@ const Dashboard = () => {
                   {element.namespace}
                 </Card.Subtitle>
                 <Card.Text id="card-text">{element.description}</Card.Text>
-
                 <div
                   className="border border-success rounded-pill chip-action"
                   onClick={() => handleAddMaintainerDialog(element.id, true)}
@@ -159,6 +160,28 @@ const Dashboard = () => {
                   namespace={element.name}
                   show={showGenerateTokenDialog[element.id]}
                   onHide={() => handleGenerateTokenDialog(element.id, false)}
+                />
+                <div
+                  className="border border-success rounded-pill chip-action"
+                  onClick={() => handleAddMaintainerDialog(element.id, true)}
+                >
+                  Add maintainers
+                </div>
+                <AddNamespaceMaintainerFormDialog
+                  namespace={element.name}
+                  show={addMaintainerDialogState[element.id]}
+                  onHide={() => handleAddMaintainerDialog(element.id, false)}
+                />
+                <div
+                  className="border border-danger rounded-pill chip-action"
+                  onClick={() => handleRemoveMaintainerDialog(element.id, true)}
+                >
+                  Remove maintainers
+                </div>
+                <RemoveNamespaceMaintainerFormDialog
+                  namespace={element.name}
+                  show={removeMaintainerDialogState[element.id]}
+                  onHide={() => handleRemoveMaintainerDialog(element.id, false)}
                 />
               </Card.Body>
             </Card>

--- a/registry/src/pages/removeNamespaceMaintainerDialogForm.js
+++ b/registry/src/pages/removeNamespaceMaintainerDialogForm.js
@@ -1,0 +1,104 @@
+import { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Button from "react-bootstrap/Button";
+import Modal from "react-bootstrap/Modal";
+import {
+  removeNamespaceMaintainer,
+  resetMessages,
+} from "../store/actions/namespaceMaintainersActions";
+
+const RemoveNamespaceMaintainerFormDialog = (props) => {
+  const [username, setUsername] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const currUsername = useSelector((state) => state.auth.username);
+  const uuid = useSelector((state) => state.auth.uuid);
+  const successMessage = useSelector(
+    (state) => state.addRemoveNamespaceMaintainer.successMessage
+  );
+  const errorMessage = useSelector(
+    (state) => state.addRemoveNamespaceMaintainer.errorMessage
+  );
+
+  const dispatch = useDispatch();
+
+  const onSubmit = (event) => {
+    dispatch(resetMessages());
+    event.preventDefault();
+
+    // If the form input is not valid. Do not proceed.
+    if (!validateForm()) {
+      return;
+    }
+
+    dispatch(
+      removeNamespaceMaintainer(
+        {
+          uuid: uuid,
+          namespace: props.namespace,
+          username_to_be_removed: username,
+          package: props.package,
+        },
+        currUsername
+      )
+    );
+  };
+
+  const resetData = () => {
+    setUsername("");
+    setValidationError("");
+    dispatch(resetMessages());
+  };
+
+  const validateForm = () => {
+    if (!username) {
+      setValidationError("Username is required");
+      return false;
+    }
+
+    setValidationError("");
+    return true;
+  };
+
+  return (
+    <form id="add-maintainer-form">
+      <Modal
+        {...props}
+        size="md"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        onExit={resetData}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Remove namespace maintainer
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <label>Enter username</label>
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            value={username}
+            id="add-maintainer-input"
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {validationError && (
+            <p id="add-maintainer-error">{validationError}</p>
+          )}
+          {successMessage && (
+            <p id="add-maintainer-success">{successMessage}</p>
+          )}
+          {errorMessage && <p id="add-maintainer-error">{errorMessage}</p>}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="danger" onClick={onSubmit}>
+            Remove
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </form>
+  );
+};
+
+export default RemoveNamespaceMaintainerFormDialog;

--- a/registry/src/store/actions/namespaceMaintainersActions.js
+++ b/registry/src/store/actions/namespaceMaintainersActions.js
@@ -1,0 +1,108 @@
+import axios from "axios";
+
+export const ADD_NAMESPACE_MAINTAINER_REQUEST =
+  "ADD_NAMESPACE_MAINTAINER_REQUEST";
+export const ADD_NAMESPACE_MAINTAINER_SUCCESS =
+  "ADD_NAMESPACE_MAINTAINER_SUCCESS";
+export const ADD_NAMESPACE_MAINTAINER_FAILURE =
+  "ADD_NAMESPACE_MAINTAINER_FAILURE";
+
+export const REMOVE_NAMESPACE_MAINTAINER_REQUEST =
+  "REMOVE_NAMESPACE_MAINTAINER_REQUEST";
+export const REMOVE_NAMESPACE_MAINTAINER_SUCCESS =
+  "REMOVE_NAMESPACE_MAINTAINER_SUCCESS";
+export const REMOVE_NAMESPACE_MAINTAINER_FAILURE =
+  "REMOVE_NAMESPACE_MAINTAINER_FAILURE";
+
+export const RESET_ERROR_MESSAGE = "RESET_ERROR_MESSAGE";
+
+export const addNamespaceMaintainer = (data, username) => async (dispatch) => {
+  let formData = new FormData();
+  formData.append("uuid", data.uuid);
+  formData.append("username", data.username_to_be_added);
+  formData.append("namespace", data.namespace);
+
+  try {
+    dispatch({
+      type: ADD_NAMESPACE_MAINTAINER_REQUEST,
+    });
+
+    const result = await axios({
+      method: "post",
+      url: `${process.env.REACT_APP_REGISTRY_API_URL}/${username}/namespace/maintainer`,
+      data: formData,
+    });
+
+    if (result.data.code === 200) {
+      dispatch({
+        type: ADD_NAMESPACE_MAINTAINER_SUCCESS,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    } else {
+      dispatch({
+        type: ADD_NAMESPACE_MAINTAINER_FAILURE,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    }
+  } catch (error) {
+    dispatch({
+      type: ADD_NAMESPACE_MAINTAINER_FAILURE,
+      payload: {
+        message: error.response.data.message,
+      },
+    });
+  }
+};
+
+export const removeNamespaceMaintainer =
+  (data, username) => async (dispatch) => {
+    let formData = new FormData();
+    formData.append("uuid", data.uuid);
+    formData.append("username", data.username_to_be_removed);
+    formData.append("namespace", data.namespace);
+
+    try {
+      dispatch({
+        type: REMOVE_NAMESPACE_MAINTAINER_REQUEST,
+      });
+
+      const result = await axios({
+        method: "post",
+        url: `${process.env.REACT_APP_REGISTRY_API_URL}/${username}/namespace/maintainer/remove`,
+        data: formData,
+      });
+
+      if (result.data.code === 200) {
+        dispatch({
+          type: REMOVE_NAMESPACE_MAINTAINER_SUCCESS,
+          payload: {
+            message: result.data.message,
+          },
+        });
+      } else {
+        dispatch({
+          type: REMOVE_NAMESPACE_MAINTAINER_FAILURE,
+          payload: {
+            message: result.data.message,
+          },
+        });
+      }
+    } catch (error) {
+      dispatch({
+        type: REMOVE_NAMESPACE_MAINTAINER_FAILURE,
+        payload: {
+          message: error.response.data.message,
+        },
+      });
+    }
+  };
+
+export const resetMessages = () => (dispatch) => {
+  dispatch({
+    type: RESET_ERROR_MESSAGE,
+  });
+};

--- a/registry/src/store/reducers/namespaceMaintainersReducer.js
+++ b/registry/src/store/reducers/namespaceMaintainersReducer.js
@@ -1,0 +1,47 @@
+import {
+  ADD_NAMESPACE_MAINTAINER_SUCCESS,
+  ADD_NAMESPACE_MAINTAINER_FAILURE,
+  RESET_ERROR_MESSAGE,
+  REMOVE_NAMESPACE_MAINTAINER_SUCCESS,
+  REMOVE_NAMESPACE_MAINTAINER_FAILURE,
+} from "../actions/namespaceMaintainersActions";
+
+const initialState = {
+  successMessage: null,
+  errorMessage: null,
+};
+
+const addRemoveNamespaceMaintainerReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case ADD_NAMESPACE_MAINTAINER_SUCCESS:
+      return {
+        ...state,
+        successMessage: action.payload.message,
+      };
+    case ADD_NAMESPACE_MAINTAINER_FAILURE:
+      return {
+        ...state,
+        errorMessage: action.payload.message,
+      };
+    case REMOVE_NAMESPACE_MAINTAINER_SUCCESS:
+      return {
+        ...state,
+        successMessage: action.payload.message,
+      };
+    case REMOVE_NAMESPACE_MAINTAINER_FAILURE:
+      return {
+        ...state,
+        errorMessage: action.payload.message,
+      };
+    case RESET_ERROR_MESSAGE:
+      return {
+        ...state,
+        successMessage: null,
+        errorMessage: null,
+      };
+    default:
+      return state;
+  }
+};
+
+export default addRemoveNamespaceMaintainerReducer;

--- a/registry/src/store/reducers/rootReducer.js
+++ b/registry/src/store/reducers/rootReducer.js
@@ -11,6 +11,7 @@ import adminReducer from "./adminReducer";
 import { combineReducers } from "redux";
 import addRemoveMaintainerReducer from "./addRemoveMaintainerReducer";
 import generateNamespaceTokenReducer from "./generateNamespaceTokenReducer";
+import addRemoveNamespaceMaintainerReducer from "./namespaceMaintainersReducer";
 
 const rootReducer = combineReducers({
   auth: authReducer,
@@ -25,6 +26,7 @@ const rootReducer = combineReducers({
   generateNamespaceToken: generateNamespaceTokenReducer,
   admin: adminReducer,
   createNamespace: createNamespaceReducer,
+  addRemoveNamespaceMaintainer: addRemoveNamespaceMaintainerReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
- [x] Fixed the logic for fetching namespace & packages of a user.
- [x] Hide Remove Maintainer from package option if user is not a namespace admin/maintainer.
- [x] Added UI for adding / removing namespace maintainer.
- [x] Fixed the API for adding/removing package maintainers to allow namespace maintainers to add/remove package maintainers.
- [x] Hide Remove Namespace maintainer button if user is not a namespace admin.