### PR TITLE
feat: added apis to add/remove admins

### DIFF
--- a/flask/user.py
+++ b/flask/user.py
@@ -633,7 +633,7 @@ def remove_admins_from_namespace(username):
         return jsonify({"message": "Namespace not found", "code": 404}), 404
     
     # Check if the current user has authority to remove admins.
-    # Only namespace authors can remove namespace admins.
+    # Only namespace authors or admins can remove namespace admins.
     if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=namespace_doc) and not checkIfNamespaceAuthor(user_id=user["_id"], namespace=namespace_doc):
         return (
             jsonify(
@@ -649,7 +649,12 @@ def remove_admins_from_namespace(username):
         return jsonify(
             {"message": "Username to be removed as a admin not found", "code": 404}
         )
-    
+
+    # Check if a user is trying to remove original namespace author from admin role.
+    # Do not allow users to remove original namespace authors from admin role.
+    if str(namespace_doc["author"]) == str(username_to_be_removed["_id"]):
+        return jsonify({"code": 401, "message": "Namespace owners cannot be removed from admins"})
+
     # Update the document only if the user_to_be_added["_id"] is not already in the admins list.
     result = db.namespaces.update_one(
         {"namespace": namespace, "admins": username_to_be_removed["_id"]},

--- a/flask/user.py
+++ b/flask/user.py
@@ -634,7 +634,7 @@ def remove_admins_from_namespace(username):
     
     # Check if the current user has authority to remove admins.
     # Only namespace authors can remove namespace admins.
-    if not checkIfNamespaceAuthor(user_id=user["_id"], namespace=namespace_doc):
+    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=namespace_doc) and not checkIfNamespaceAuthor(user_id=user["_id"], namespace=namespace_doc):
         return (
             jsonify(
                 {"message": "User is not authorized to remove admins", "code": 401}

--- a/flask/user.py
+++ b/flask/user.py
@@ -533,7 +533,139 @@ def remove_maintainers_from_namespace(username):
         return jsonify({"message": "Maintainer removed successfully", "code": 200}), 200
     else:
         return jsonify({"message": "Namespace maintainer not found", "code": 200}), 200
+    
+@app.route("/<username>/namespace/admin", methods=["POST"])
+def add_admins_to_namespace(username):
+    uuid = request.form.get("uuid")
+    username_to_be_added = request.form.get("username")
+    namespace = request.form.get("namespace")
 
+    # Validating the data coming with request.
+    if not uuid:
+        return jsonify({"message": "Unauthorized", "code": 401}), 401
+    
+    if not username_to_be_added:
+        return (
+            jsonify(
+                {"message": "Please enter the username to be added", "code": 400}
+            ),
+            400,
+        )
+    
+    if not namespace:
+        return jsonify({"message": "Please enter the namespace name", "code": 400}), 400
+    
+    # Get the user from the database using uuid.
+    user = db.users.find_one({"uuid": uuid})
+
+    # Check if current user is authorized to access this API.
+    if not user or user["username"] != username:
+        return jsonify({"message": "Unauthorized", "code": 401}), 401
+    
+    # Get the namespace from the database.  
+    namespace_doc = db.namespaces.find_one({"namespace": namespace})
+
+    # Check if namespace does not exists.
+    if not namespace_doc:
+        return jsonify({"message": "Namespace not found", "code": 404}), 404
+    
+    # Only namespace admins can add new admins to the namespace or namespace authors have the authority to add admins.
+    if not checkIsNamespaceAdmin(user_id=user["_id"], namespace=namespace_doc) and not checkIfNamespaceAuthor(user_id=user["_id"], namespace=namespace_doc):
+        return (
+            jsonify(
+                {"message": "User is not authorized to add namespace admins", "code": 401}
+            ),
+            401,
+        )
+    
+    # Get the user to be added using the username received in the request body.
+    username_to_be_added = db.users.find_one({"username": username_to_be_added})
+
+    if not username_to_be_added:
+        return jsonify(
+            {"message": "Username to be added as a admin not found", "code": 404}
+        )
+    
+    # Update the document only if the user_to_be_added["_id"] is not already in the admins list.
+    result = db.namespaces.update_one(
+        {"namespace": namespace, "admins": {"$ne": username_to_be_added["_id"]}},
+        {"$addToSet": {"admins": username_to_be_added["_id"]}},
+    )
+
+    if result.modified_count > 0:
+        return jsonify({"message": "Admin added successfully", "code": 200}), 200
+    else:
+        return jsonify({"message": "Admin already added", "code": 200}), 200
+    
+@app.route("/<username>/namespace/admin/remove", methods=["POST"])
+def remove_admins_from_namespace(username):
+    uuid = request.form.get("uuid")
+    username_to_be_removed = request.form.get("username")
+    namespace = request.form.get("namespace")
+
+    # Validating the data coming with request.
+    if not uuid:
+        return jsonify({"message": "Unauthorized", "code": 401}), 401
+    
+    if not username_to_be_removed:
+        return (
+            jsonify(
+                {"message": "Please enter the username to be removed", "code": 400}
+            ),
+            400,
+        )
+    
+    if not namespace:
+        return jsonify({"message": "Please enter the namespace name", "code": 400}), 400
+    
+    # Get the user from the database using uuid.
+    user = db.users.find_one({"uuid": uuid})
+
+    # Check if current user is authorized to access this API.
+    if not user or user["username"] != username:
+        return jsonify({"message": "Unauthorized", "code": 401}), 401
+    
+    # Get the namespace from the database.
+    namespace_doc = db.namespaces.find_one({"namespace": namespace})
+
+    # Check if namespace does not exists.
+    if not namespace_doc:
+        return jsonify({"message": "Namespace not found", "code": 404}), 404
+    
+    # Check if the current user has authority to remove admins.
+    # Only namespace authors can remove namespace admins.
+    if not checkIfNamespaceAuthor(user_id=user["_id"], namespace=namespace_doc):
+        return (
+            jsonify(
+                {"message": "User is not authorized to remove admins", "code": 401}
+            ),
+            401,
+        )
+    
+    # Get the user to be removed using the username received in the request body.
+    username_to_be_removed = db.users.find_one({"username": username_to_be_removed})
+
+    if not username_to_be_removed:
+        return jsonify(
+            {"message": "Username to be removed as a admin not found", "code": 404}
+        )
+    
+    # Update the document only if the user_to_be_added["_id"] is not already in the admins list.
+    result = db.namespaces.update_one(
+        {"namespace": namespace, "admins": username_to_be_removed["_id"]},
+        {"$pull": {"admins": username_to_be_removed["_id"]}},
+    )
+
+    if result.modified_count > 0:
+        return jsonify({"message": "Admin removed successfully", "code": 200}), 200
+    else:
+        return jsonify({"message": "Admin already removed", "code": 200}), 200
+
+
+# This function checks if user is an author of a namespace.
+def checkIfNamespaceAuthor(user_id, namespace):
+    author_id = namespace["author"]
+    return user_id == author_id
 
 # This function checks if user is a maintainer of a namespace.
 def checkIfNamespaceMaintainer(user_id, namespace):

--- a/registry/src/App.css
+++ b/registry/src/App.css
@@ -137,5 +137,13 @@ body {
     cursor: pointer;
     padding: 8px;
     width: fit-content;
-    margin-bottom: 4px;
+    margin: 4px 4px 0px 0px;
+}
+
+.chip-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    align-items: center;
+    width: 100%;
 }

--- a/registry/src/pages/addNamespaceAdminForm.js
+++ b/registry/src/pages/addNamespaceAdminForm.js
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import {
+  addNamespaceAdmin,
+  resetMessages,
+} from "../store/actions/namespaceAdminsActions";
+
+const AddNamespaceAdminFormDialog = (props) => {
+  const [username, setUsername] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const currUsername = useSelector((state) => state.auth.username);
+  const uuid = useSelector((state) => state.auth.uuid);
+  const successMessage = useSelector(
+    (state) => state.addRemoveNamespaceAdmin.successMessage
+  );
+  const errorMessage = useSelector(
+    (state) => state.addRemoveNamespaceAdmin.errorMessage
+  );
+
+  const dispatch = useDispatch();
+
+  const onSubmit = (event) => {
+    dispatch(resetMessages());
+    event.preventDefault();
+
+    // If the form input is not valid. Do not proceed.
+    if (!validateForm()) {
+      return;
+    }
+
+    dispatch(
+      addNamespaceAdmin(
+        {
+          uuid: uuid,
+          namespace: props.namespace,
+          username_to_be_added: username,
+        },
+        currUsername
+      )
+    );
+  };
+
+  const resetData = () => {
+    setUsername("");
+    setValidationError("");
+    dispatch(resetMessages());
+  };
+
+  const validateForm = () => {
+    if (!username) {
+      setValidationError("Username is required");
+      return false;
+    }
+
+    setValidationError("");
+    return true;
+  };
+
+  return (
+    <form id="add-maintainer-form">
+      <Modal
+        {...props}
+        size="md"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        onExit={resetData}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Add namespace admin
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <label>Enter username</label>
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            value={username}
+            id="add-maintainer-input"
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {validationError && (
+            <p id="add-maintainer-error">{validationError}</p>
+          )}
+          {successMessage && (
+            <p id="add-maintainer-success">{successMessage}</p>
+          )}
+          {errorMessage && <p id="add-maintainer-error">{errorMessage}</p>}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="success" onClick={onSubmit}>
+            Add
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </form>
+  );
+};
+
+export default AddNamespaceAdminFormDialog;

--- a/registry/src/pages/dashboard.js
+++ b/registry/src/pages/dashboard.js
@@ -12,11 +12,17 @@ import RemoveMaintainerFormDialog from "./removeMaintainerDialogForm";
 import GenerateNamespaceTokenDialogForm from "./generateNamespaceTokenDialogForm";
 import AddNamespaceMaintainerFormDialog from "./addNamespaceMaintainerDialogForm";
 import RemoveNamespaceMaintainerFormDialog from "./removeNamespaceMaintainerDialogForm";
+import AddNamespaceAdminFormDialog from "./addNamespaceAdminForm";
+import RemoveNamespaceAdminFormDialog from "./removeNamespaceAdminForm";
 
 const Dashboard = () => {
   const [addMaintainerDialogState, setAddMaintainerDialogState] = useState({});
   const [showGenerateTokenDialog, setshowGenerateTokenDialog] = useState({});
   const [removeMaintainerDialogState, setRemoveMaintainerDialogState] =
+    useState({});
+  const [addNamespaceAdminDialogState, setAddNamespaceAdminDialogState] =
+    useState({});
+  const [removeNamespaceAdminDialogState, setRemoveNamespaceAdminDialogState] =
     useState({});
   const username = useSelector((state) => state.auth.username);
   const packages = useSelector((state) => state.dashboard.packages);
@@ -51,6 +57,20 @@ const Dashboard = () => {
 
   const handleGenerateTokenDialog = (itemId, value) => {
     setshowGenerateTokenDialog((prevState) => ({
+      ...prevState,
+      [itemId]: value,
+    }));
+  };
+
+  const handleAddNamespaceAdminDialog = (itemId, value) => {
+    setAddNamespaceAdminDialogState((prevState) => ({
+      ...prevState,
+      [itemId]: value,
+    }));
+  };
+
+  const handleRemoveNamespaceAdminDialog = (itemId, value) => {
+    setRemoveNamespaceAdminDialogState((prevState) => ({
       ...prevState,
       [itemId]: value,
     }));
@@ -94,11 +114,23 @@ const Dashboard = () => {
                   {element.namespace}
                 </Card.Subtitle>
                 <Card.Text id="card-text">{element.description}</Card.Text>
-                <div
-                  className="border border-success rounded-pill chip-action"
-                  onClick={() => handleAddMaintainerDialog(element.id, true)}
-                >
-                  Add Maintainers
+                <div className="chip-container">
+                  <div
+                    className="border border-success rounded-pill chip-action"
+                    onClick={() => handleAddMaintainerDialog(element.id, true)}
+                  >
+                    Add Maintainers
+                  </div>
+                  {element.isNamespaceMaintainer ? (
+                    <div
+                      className="border border-danger rounded-pill chip-action"
+                      onClick={() =>
+                        handleRemoveMaintainerDialog(element.id, true)
+                      }
+                    >
+                      Remove Maintainers
+                    </div>
+                  ) : null}
                 </div>
                 <AddMaintainerFormDialog
                   package={element.name}
@@ -106,16 +138,6 @@ const Dashboard = () => {
                   show={addMaintainerDialogState[element.id]}
                   onHide={() => handleAddMaintainerDialog(element.id, false)}
                 />
-                {element.isNamespaceMaintainer ? (
-                  <div
-                    className="border border-danger rounded-pill chip-action"
-                    onClick={() =>
-                      handleRemoveMaintainerDialog(element.id, true)
-                    }
-                  >
-                    Remove Maintainers
-                  </div>
-                ) : null}
                 <RemoveMaintainerFormDialog
                   package={element.name}
                   namespace={element.namespace}
@@ -150,39 +172,74 @@ const Dashboard = () => {
                   </a>
                 </Card.Title>
                 <Card.Text id="card-text">{element.description}</Card.Text>
-                <div
-                  className="border border-success rounded-pill chip-action"
-                  onClick={() => handleGenerateTokenDialog(element.id, true)}
-                >
-                  Generate Token
+                <div className="chip-container">
+                  <div
+                    className="border border-success rounded-pill chip-action"
+                    onClick={() => handleGenerateTokenDialog(element.id, true)}
+                  >
+                    Generate Token
+                  </div>
+                  {element.isNamespaceAdmin ? (
+                    <div
+                      className="border border-success rounded-pill chip-action"
+                      onClick={() =>
+                        handleAddNamespaceAdminDialog(element.id, true)
+                      }
+                    >
+                      Add admins
+                    </div>
+                  ) : null}
+                  {element.isNamespaceAdmin ? (
+                    <div
+                      className="border border-success rounded-pill chip-action"
+                      onClick={() =>
+                        handleRemoveNamespaceAdminDialog(element.id, true)
+                      }
+                    >
+                      Remove admins
+                    </div>
+                  ) : null}
+                  <div
+                    className="border border-success rounded-pill chip-action"
+                    onClick={() => handleAddMaintainerDialog(element.id, true)}
+                  >
+                    Add maintainers
+                  </div>
+                  {element.isNamespaceAdmin ? (
+                    <div
+                      className="border border-danger rounded-pill chip-action"
+                      onClick={() =>
+                        handleRemoveMaintainerDialog(element.id, true)
+                      }
+                    >
+                      Remove maintainers
+                    </div>
+                  ) : null}
                 </div>
                 <GenerateNamespaceTokenDialogForm
                   namespace={element.name}
                   show={showGenerateTokenDialog[element.id]}
                   onHide={() => handleGenerateTokenDialog(element.id, false)}
                 />
-                <div
-                  className="border border-success rounded-pill chip-action"
-                  onClick={() => handleAddMaintainerDialog(element.id, true)}
-                >
-                  Add maintainers
-                </div>
+                <AddNamespaceAdminFormDialog
+                  namespace={element.name}
+                  show={addNamespaceAdminDialogState[element.id]}
+                  onHide={() =>
+                    handleAddNamespaceAdminDialog(element.id, false)
+                  }
+                />
+                <RemoveNamespaceAdminFormDialog
+                  namespace={element.name}
+                  show={removeNamespaceAdminDialogState[element.id]}
+                  onHide={() =>
+                    handleRemoveNamespaceAdminDialog(element.id, false)
+                  }
+                />
                 <AddNamespaceMaintainerFormDialog
                   namespace={element.name}
                   show={addMaintainerDialogState[element.id]}
                   onHide={() => handleAddMaintainerDialog(element.id, false)}
                 />
-                {element.isNamespaceAdmin ? (
-                  <div
-                    className="border border-danger rounded-pill chip-action"
-                    onClick={() =>
-                      handleRemoveMaintainerDialog(element.id, true)
-                    }
-                  >
-                    Remove maintainers
-                  </div>
-                ) : null}
-
                 <RemoveNamespaceMaintainerFormDialog
                   namespace={element.name}
                   show={removeMaintainerDialogState[element.id]}

--- a/registry/src/pages/removeNamespaceAdminForm.js
+++ b/registry/src/pages/removeNamespaceAdminForm.js
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import {
+  removeNamespaceAdmin,
+  resetMessages,
+} from "../store/actions/namespaceAdminsActions";
+
+const RemoveNamespaceAdminFormDialog = (props) => {
+  const [username, setUsername] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const currUsername = useSelector((state) => state.auth.username);
+  const uuid = useSelector((state) => state.auth.uuid);
+  const successMessage = useSelector(
+    (state) => state.addRemoveNamespaceAdmin.successMessage
+  );
+  const errorMessage = useSelector(
+    (state) => state.addRemoveNamespaceAdmin.errorMessage
+  );
+
+  const dispatch = useDispatch();
+
+  const onSubmit = (event) => {
+    dispatch(resetMessages());
+    event.preventDefault();
+
+    // If the form input is not valid. Do not proceed.
+    if (!validateForm()) {
+      return;
+    }
+
+    dispatch(
+      removeNamespaceAdmin(
+        {
+          uuid: uuid,
+          namespace: props.namespace,
+          username_to_be_removed: username,
+        },
+        currUsername
+      )
+    );
+  };
+
+  const resetData = () => {
+    setUsername("");
+    setValidationError("");
+    dispatch(resetMessages());
+  };
+
+  const validateForm = () => {
+    if (!username) {
+      setValidationError("Username is required");
+      return false;
+    }
+
+    setValidationError("");
+    return true;
+  };
+
+  return (
+    <form id="add-maintainer-form">
+      <Modal
+        {...props}
+        size="md"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+        onExit={resetData}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="contained-modal-title-vcenter">
+            Remove namespace admin
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <label>Enter username</label>
+          <input
+            type="text"
+            name="username"
+            placeholder="Username"
+            value={username}
+            id="add-maintainer-input"
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          {validationError && (
+            <p id="add-maintainer-error">{validationError}</p>
+          )}
+          {successMessage && (
+            <p id="add-maintainer-success">{successMessage}</p>
+          )}
+          {errorMessage && <p id="add-maintainer-error">{errorMessage}</p>}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="success" onClick={onSubmit}>
+            Add
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </form>
+  );
+};
+
+export default RemoveNamespaceAdminFormDialog;

--- a/registry/src/pages/removeNamespaceAdminForm.js
+++ b/registry/src/pages/removeNamespaceAdminForm.js
@@ -91,8 +91,8 @@ const RemoveNamespaceAdminFormDialog = (props) => {
           {errorMessage && <p id="add-maintainer-error">{errorMessage}</p>}
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="success" onClick={onSubmit}>
-            Add
+          <Button variant="danger" onClick={onSubmit}>
+            Remove
           </Button>
         </Modal.Footer>
       </Modal>

--- a/registry/src/store/actions/namespaceAdminsActions.js
+++ b/registry/src/store/actions/namespaceAdminsActions.js
@@ -1,0 +1,101 @@
+import axios from "axios";
+
+export const ADD_NAMESPACE_ADMIN_REQUEST = "ADD_NAMESPACE_ADMIN_REQUEST";
+export const ADD_NAMESPACE_ADMIN_SUCCESS = "ADD_NAMESPACE_ADMIN_SUCCESS";
+export const ADD_NAMESPACE_ADMIN_FAILURE = "ADD_NAMESPACE_ADMIN_FAILURE";
+
+export const REMOVE_NAMESPACE_ADMIN_REQUEST = "REMOVE_NAMESPACE_ADMIN_REQUEST";
+export const REMOVE_NAMESPACE_ADMIN_SUCCESS = "REMOVE_NAMESPACE_ADMIN_SUCCESS";
+export const REMOVE_NAMESPACE_ADMIN_FAILURE = "REMOVE_NAMESPACE_ADMIN_FAILURE";
+
+export const RESET_ERROR_MESSAGE = "RESET_ERROR_MESSAGE";
+
+export const addNamespaceAdmin = (data, username) => async (dispatch) => {
+  let formData = new FormData();
+  formData.append("uuid", data.uuid);
+  formData.append("username", data.username_to_be_added);
+  formData.append("namespace", data.namespace);
+
+  try {
+    dispatch({
+      type: ADD_NAMESPACE_ADMIN_REQUEST,
+    });
+
+    const result = await axios({
+      method: "post",
+      url: `${process.env.REACT_APP_REGISTRY_API_URL}/${username}/namespace/admin`,
+      data: formData,
+    });
+
+    if (result.data.code === 200) {
+      dispatch({
+        type: ADD_NAMESPACE_ADMIN_SUCCESS,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    } else {
+      dispatch({
+        type: ADD_NAMESPACE_ADMIN_FAILURE,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    }
+  } catch (error) {
+    dispatch({
+      type: ADD_NAMESPACE_ADMIN_FAILURE,
+      payload: {
+        message: error.response.data.message,
+      },
+    });
+  }
+};
+
+export const removeNamespaceAdmin = (data, username) => async (dispatch) => {
+  let formData = new FormData();
+  formData.append("uuid", data.uuid);
+  formData.append("username", data.username_to_be_removed);
+  formData.append("namespace", data.namespace);
+
+  try {
+    dispatch({
+      type: REMOVE_NAMESPACE_ADMIN_REQUEST,
+    });
+
+    const result = await axios({
+      method: "post",
+      url: `${process.env.REACT_APP_REGISTRY_API_URL}/${username}/namespace/admin/remove`,
+      data: formData,
+    });
+
+    if (result.data.code === 200) {
+      dispatch({
+        type: REMOVE_NAMESPACE_ADMIN_SUCCESS,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    } else {
+      dispatch({
+        type: REMOVE_NAMESPACE_ADMIN_FAILURE,
+        payload: {
+          message: result.data.message,
+        },
+      });
+    }
+  } catch (error) {
+    dispatch({
+      type: REMOVE_NAMESPACE_ADMIN_FAILURE,
+      payload: {
+        message: error.response.data.message,
+      },
+    });
+  }
+};
+
+export const resetMessages = () => (dispatch) => {
+  dispatch({
+    type: RESET_ERROR_MESSAGE,
+  });
+};

--- a/registry/src/store/reducers/namespaceAdminReducer.js
+++ b/registry/src/store/reducers/namespaceAdminReducer.js
@@ -1,0 +1,47 @@
+import {
+  ADD_NAMESPACE_ADMIN_SUCCESS,
+  ADD_NAMESPACE_ADMIN_FAILURE,
+  REMOVE_NAMESPACE_ADMIN_SUCCESS,
+  REMOVE_NAMESPACE_ADMIN_FAILURE,
+  RESET_ERROR_MESSAGE,
+} from "../actions/namespaceAdminsActions";
+
+const initialState = {
+  successMessage: null,
+  errorMessage: null,
+};
+
+const addRemoveNamespaceAdminReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case ADD_NAMESPACE_ADMIN_SUCCESS:
+      return {
+        ...state,
+        successMessage: action.payload.message,
+      };
+    case ADD_NAMESPACE_ADMIN_FAILURE:
+      return {
+        ...state,
+        errorMessage: action.payload.message,
+      };
+    case REMOVE_NAMESPACE_ADMIN_SUCCESS:
+      return {
+        ...state,
+        successMessage: action.payload.message,
+      };
+    case REMOVE_NAMESPACE_ADMIN_FAILURE:
+      return {
+        ...state,
+        errorMessage: action.payload.message,
+      };
+    case RESET_ERROR_MESSAGE:
+      return {
+        ...state,
+        successMessage: null,
+        errorMessage: null,
+      };
+    default:
+      return state;
+  }
+};
+
+export default addRemoveNamespaceAdminReducer;

--- a/registry/src/store/reducers/rootReducer.js
+++ b/registry/src/store/reducers/rootReducer.js
@@ -12,6 +12,7 @@ import { combineReducers } from "redux";
 import addRemoveMaintainerReducer from "./addRemoveMaintainerReducer";
 import generateNamespaceTokenReducer from "./generateNamespaceTokenReducer";
 import addRemoveNamespaceMaintainerReducer from "./namespaceMaintainersReducer";
+import addRemoveNamespaceAdminReducer from "./namespaceAdminReducer";
 
 const rootReducer = combineReducers({
   auth: authReducer,
@@ -27,6 +28,7 @@ const rootReducer = combineReducers({
   admin: adminReducer,
   createNamespace: createNamespaceReducer,
   addRemoveNamespaceMaintainer: addRemoveNamespaceMaintainerReducer,
+  addRemoveNamespaceAdmin: addRemoveNamespaceAdminReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
- [x] Added APIs for adding / removing admins to a namespace.
- [x] Added UI for adding/removing namespace admins. 

Registry users will be able to add other users as admins to a namespace which will enable them to have same authority  as the original admin except the authority to remove admins. I have given that authority to original admin/author of the namespace for now. But of course, we can change that if there is a need. 

Testable link - https://registry-frontend-arteevraina.vercel.app