### PR TITLE
fix: docker command for running containers in macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # backend
 /backend/.env
+/backend/.venv
 /backend/vercel.json
 /backend/static/*.tar.gz
 /backend/__pycache__/

--- a/backend/docker/backend.Dockerfile
+++ b/backend/docker/backend.Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM python:3.10-alpine AS builder
 
 WORKDIR /src
 COPY requirements.txt /src
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,mode=0777,target=/root/.cache/pip \
     pip3 install -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
### Description

- [x] This resolved the issue of running containers in macos.
- [x] Adds environment folder to ``.gitignore``.

### Related Issues

_List all the relevant issues this PR addresses or closes._

### How to Test

_Always include a short set of instructions on how to test the changes made in this PR._

### Link for Testing

_Always provide a link which reviewers can use for testing._
